### PR TITLE
ci: Add renovate config presets to be used across repos

### DIFF
--- a/renovate-config-group-dev-dependencies.json
+++ b/renovate-config-group-dev-dependencies.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Preset to group all non-major dev dependency updates.",
+  "packageRules": [
+    {
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "groupName": "devDependencies (non-major)"
+    }
+  ]
+}

--- a/renovate-config-group-package-json.json
+++ b/renovate-config-group-package-json.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Preset to group dependency updates by npm project",
+  "packageRules": [
+    {
+      "description": "Group dependencies from package.json files",
+      "matchFileNames": ["**/package.json"],
+      "groupName": "All npm project updates"
+    }
+  ]
+}

--- a/renovate-config.json
+++ b/renovate-config.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Default preset for use with simpleclub's repos",
+  "extends": [
+    "config:recommended",
+    ":semanticCommits",
+    ":semanticCommitScope(deps)",
+    ":combinePatchMinorReleases",
+    ":disableDependencyDashboard",
+    ":maintainLockFilesMonthly",
+    ":label(dependencies)",
+    ":prHourlyLimit2",
+    ":prConcurrentLimit10",
+    ":timezone(Etc/UTC)",
+    ":widenPeerDependencies",
+    "helpers:disableTypesNodeMajor"
+  ],
+  "hostRules": [
+    {
+      "matchHost": "https://npm.pkg.github.com/",
+      "hostType": "npm",
+      "encrypted": {
+        "token": "wcFMA/xDdHCJBTolAQ//WdybiY+E82jSgAO2Ug5WtjA5BE9kaa/SjO8YBAPL0VB2QtpJsuoUQY3w4BbSYQAFCu9ZAjBnRxby370PLDYCFe9vOcnnZvNcq5r1mAA8ibjLbxlfsaHfNsMCyI4pw8DIM1AnWpswwb7yVArh4zb47kQFp/8/hrsWl1ezjjFe2KFb82FRLrxiwG67a5hLWdESyO30M16Uj3tOYFVu7+vanHwKaoX2gIxwtdQ0cWv/tBd3kWyEzn2m5P87EWdc9Is3cchPH0FXAsLj2KnlHAAzwU9HSkpttf2gKWsnV1P0eQE5fnQu+y7OJDdaT00z9Z7qVqzBnHt0bvy4r/gr8CZoqF+qZWekTdtLSsp9B61qJo/eJp5QFTQgpY3zoZm/1QKy7hWludQUpXm4mNrxvxIb+mVyzaCGMR8REe3mVBk3jM0KcCqHukdtAROT9c69prNwFzqmNSh5ZXbTRKs/+DKhjE1QzOaxEUDma5lk530hyZgbBi4JGIk41ynFcpmS7Kry3yPZl5KbiLFZ1OI8q2FNJSOLPtT7y2awBu/K+9PjlGymFR4gmp6w0SHbO3Kos41sfKb3p90q0K1FQbBOpKsdfWtvYp0QTv5As4RyoVa8QUOQ8jLXGBzrX+5iPDH720ZWKjPUs9M5E0xkXf7gR0FAcEfZxPaDbQZF3z/zofDCy/LSeQEb+aKMNTIHajcw0EMrL+tFeTI61GO7rtqCbCli3Zj+VHkjC+pp9ZzoscILpwIRCBqIgFGVds+a4QQSIBFe7V0zmOxJIubVqTB3pEJ1FoKwvWUpwBSNbMMxR+1VKjtoofXrCbZhVWp0txhg4pbfacKanrhEQ9RMJ5Q"
+      }
+    }
+  ],
+  "npmrc": "@simpleclub:registry=https://npm.pkg.github.com/",
+  "automergeStrategy": "squash",
+  "configMigration": true,
+  "postUpdateOptions": ["yarnDedupeHighest"],
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "addLabels": ["security"]
+  },
+  "packageRules": [
+    {
+      "matchDatasources": ["npm"],
+      "minimumReleaseAge": "3 days"
+    }
+  ]
+}


### PR DESCRIPTION
Moves renovate [config files](https://github.com/simpleclub/.github-private/blob/main/renovate-config.json) from private repo (as in private repo they can't be fetched).
