### PR TITLE
feat: Approval job for release-please PRs for only dependency updates

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-    if: github.actor == 'simpleclub-bot'
+    if: github.actor == 'simpleclub-bot' || github.actor == 'IchordeDionysos'
     steps:
       - name: Get release-please changed files
         id: changed-files

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -50,7 +50,7 @@ jobs:
             console.log(JSON.stringify(packageJsonFile));
             const packageJsonChunk = packageJsonFile.chunks[0];
             const packageJsonChanges = packageJsonChunk.changes.filter(change => change.type !== 'UnchangedLine');
-            const removedVersion = packageJsonChanges.filter(change => change.type === 'RemovedLine')[0]
+            const removedVersion = packageJsonChanges.filter(change => change.type === 'DeletedLine')[0]
               .content.match(/^\s*"version":\s*"(\d+)\.(\d+)\.(\d+)",?\s*$/);
             const addedVersion = packageJsonChanges.filter(change => change.type === 'AddedLine')[0]
               .content.match(/^\s*"version":\s*"(\d+)\.(\d+)\.(\d+)",?\s*$/);

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -32,8 +32,8 @@ jobs:
         uses: tj-actions/changed-files@v45
         with:
           files: |
-            /.github/workflows/auto-approve.yml
-            /.github/release-please-manifest.json
+            .github/workflows/auto-approve.yml
+            .github/release-please-manifest.json
             **/package.json
             **/CHANGELOG.md
       - uses: GrantBirki/git-diff-action@6679c6802dd361f930f603c0a967f0e9f074630b

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -54,12 +54,12 @@ jobs:
               .content.match(/^\s*"version":\s*"(\d+)\.(\d+)\.(\d+)",?\s*$/);
             const addedVersion = packageJsonChanges.filter(change => change.type === 'AddedLine')[0]
               .content.match(/^\s*"version":\s*"(\d+)\.(\d+)\.(\d+)",?\s*$/);
-            const didNotUpgradeMajorVersion = removedVersion[1] === addedVersion[1] && (
-              removedVersion[2] !== addedVersion[2] || removedVersion[3] !== addedVersion[3]
-            );
+            const onlyUpdatesMinorPackageVersions = addedVersion !== null && removedVersion !== null &&
+              removedVersion[1] === addedVersion[1] && (
+                removedVersion[2] !== addedVersion[2] || removedVersion[3] !== addedVersion[3]
+              );
             const checkPackageJsonChanges = packageJsonFile.chunks.length === 1 && packageJsonChanges.length === 2 &&
-              addedVersion !== null && removedVersion !== null &&
-              didNotUpgradeMajorVersion;
+              onlyUpdatesMinorPackageVersions;
 
             const changelogFile = data.files.find(file => file.path.endsWith('CHANGELOG.md'));
             console.log(JSON.stringify(changelogFile));

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           script: |
             const data = ${{steps.git-diff-action.outputs.json-diff}};
-            const checkOnlyThreeFilesChange = data.files.length === 4;
+            const checkOnlyThreeFilesChange = data.files.length === 3;
             
             const packageJsonFile = data.files.find(file => file.path.endsWith('package.json'));
             console.log(JSON.stringify(packageJsonFile));

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -31,9 +31,47 @@ jobs:
             /.github/release-please-manifest.json
             **/package.json
             **/CHANGELOG.md
+      - uses: GrantBirki/git-diff-action@vX.X.X
+        id: git-diff-action
+        with:
+          json_diff_file_output: diff.json
+          file_output_only: "true"
+      - uses: actions/github-script@v7
+        id: check-only-dependency-updates
+        with:
+          script: |
+            const data = require('${{steps.git-diff-action.outputs.json-diff-path}}');
+            const checkOnlyThreeFilesChange = data.files.length === 3;
+            
+            const packageJsonFile = data.files.find(file => file.path === 'package.json');
+            const packageJsonChunk = packageJsonFile.chunks[0];
+            const packageJsonChanges = packageJsonChunk.changes.filter(change => change.type !== 'UnchangedLine');
+            const removedVersion = packageJsonChanges.filter(change => change.type === 'RemovedLine')[0]
+              .content.match(/^\s*"version":\s*"(\d+)\.(\d+)\.(\d+)",?\s*$/);
+            const addedVersion = packageJsonChanges.filter(change => change.type === 'AddedLine')[0]
+              .content.match(/^\s*"version":\s*"(\d+)\.(\d+)\.(\d+)",?\s*$/);
+            const didNotUpgradeMajorVersion = removedVersion[1] === addedVersion[1] && (
+              removedVersion[2] !== addedVersion[2] || removedVersion[3] !== addedVersion[3]
+            );
+            const checkPackageJsonChanges = packageJsonFile.chunks.length === 1 && packageJsonChanges.length === 2 &&
+              addedVersion !== null && removedVersion !== null &&
+              didNotUpgradeMajorVersion;
+
+            const changelogFile = data.files.find(file => file.path === 'CHANGELOG.md');
+            const changelogChunk = changelogFile.chunks[0];
+            const changelogChanges = packageJsonChunk.changes.filter(change => change.type !== 'UnchangedLine');
+            const changelogAllChanges = changelogChanges.filter(change => change.content.match(/^\* /);
+            const changelogDependencyUpdates = changelogChanges.filter(change => change.content.match(/^\* \*\*deps:\*\* (update dependency|lock file maintenance) /);
+            const checkOnlyHasDependencyUpdates = changelogAllChanges.length === changelogDependencyUpdates.length;
+            const checkChangeLogChanges = changelogFile.chunks.length === 1 &&
+              checkOnlyHasDependencyUpdates;
+
+            return checkOnlyThreeFilesChange && checkPackageJson && checkChangeLogChanges;
+              
+          result-encoding: string
       - uses: hmarr/auto-approve-action@8f929096a962e83ccdfa8afcf855f39f12d4dac7
         # Only approve when the modified files have been changed
-        if: steps.changed-files.outputs.only_changed == 'true'
+        if: steps.changed-files.outputs.only_changed == 'true' && steps.check-only-dependency-updates.outputs.result == 'true'
         with:
           pull-request-number: ${{ inputs.pull-request-number }}
           review-message: 'Approving auto-generated PR'

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 2 # needed to checkout all branches for this Action to work
+          fetch-depth: 2 # required to compare the two last commits for changes
       - name: Get release-please changed files
         id: changed-files
         uses: tj-actions/changed-files@v45

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -72,7 +72,7 @@ jobs:
             const checkChangeLogChanges = changelogFile.chunks.length === 1 &&
               checkOnlyHasDependencyUpdates;
 
-            return checkOnlyThreeFilesChange && checkPackageJson && checkChangeLogChanges;
+            return checkOnlyThreeFilesChange && checkPackageJsonChanges && checkChangeLogChanges;
               
           result-encoding: string
       - uses: hmarr/auto-approve-action@8f929096a962e83ccdfa8afcf855f39f12d4dac7

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -21,6 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+      contents: read
     if: github.actor == 'simpleclub-bot' || github.actor == 'IchordeDionysos'
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -64,8 +64,8 @@ jobs:
             const changelogFile = data.files.find(file => file.path === 'CHANGELOG.md');
             const changelogChunk = changelogFile.chunks[0];
             const changelogChanges = packageJsonChunk.changes.filter(change => change.type !== 'UnchangedLine');
-            const changelogAllChanges = changelogChanges.filter(change => change.content.match(/^\* /);
-            const changelogDependencyUpdates = changelogChanges.filter(change => change.content.match(/^\* \*\*deps:\*\* (update dependency|lock file maintenance) /);
+            const changelogAllChanges = changelogChanges.filter(change => change.content.match(/^\* /));
+            const changelogDependencyUpdates = changelogChanges.filter(change => change.content.match(/^\* \*\*deps:\*\* (update dependency|lock file maintenance) /));
             const checkOnlyHasDependencyUpdates = changelogAllChanges.length === changelogDependencyUpdates.length;
             const checkChangeLogChanges = changelogFile.chunks.length === 1 &&
               checkOnlyHasDependencyUpdates;

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -47,6 +47,7 @@ jobs:
             const checkOnlyThreeFilesChange = data.files.length === 3;
             
             const packageJsonFile = data.files.find(file => file.path.endsWith('package.json'));
+            console.log(packageJsonFile);
             const packageJsonChunk = packageJsonFile.chunks[0];
             const packageJsonChanges = packageJsonChunk.changes.filter(change => change.type !== 'UnchangedLine');
             const removedVersion = packageJsonChanges.filter(change => change.type === 'RemovedLine')[0]
@@ -61,6 +62,7 @@ jobs:
               didNotUpgradeMajorVersion;
 
             const changelogFile = data.files.find(file => file.path.endsWith('CHANGELOG.md'));
+            console.log(changelogFile);
             const changelogChunk = changelogFile.chunks[0];
             const changelogChanges = packageJsonChunk.changes.filter(change => change.type !== 'UnchangedLine');
             const changelogAllChanges = changelogChanges.filter(change => change.content.match(/^\* /));

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -23,6 +23,9 @@ jobs:
       pull-requests: write
     if: github.actor == 'simpleclub-bot' || github.actor == 'IchordeDionysos'
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2 # needed to checkout all branches for this Action to work
       - name: Get release-please changed files
         id: changed-files
         uses: tj-actions/changed-files@v45

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -46,7 +46,7 @@ jobs:
             const data = ${{steps.git-diff-action.outputs.json-diff}};
             const checkOnlyThreeFilesChange = data.files.length === 3;
             
-            const packageJsonFile = data.files.find(file => file.path === 'package.json');
+            const packageJsonFile = data.files.find(file => file.path.endsWith('package.json'));
             const packageJsonChunk = packageJsonFile.chunks[0];
             const packageJsonChanges = packageJsonChunk.changes.filter(change => change.type !== 'UnchangedLine');
             const removedVersion = packageJsonChanges.filter(change => change.type === 'RemovedLine')[0]
@@ -60,7 +60,7 @@ jobs:
               addedVersion !== null && removedVersion !== null &&
               didNotUpgradeMajorVersion;
 
-            const changelogFile = data.files.find(file => file.path === 'CHANGELOG.md');
+            const changelogFile = data.files.find(file => file.path.endsWith('CHANGELOG.md'));
             const changelogChunk = changelogFile.chunks[0];
             const changelogChanges = packageJsonChunk.changes.filter(change => change.type !== 'UnchangedLine');
             const changelogAllChanges = changelogChanges.filter(change => change.content.match(/^\* /));

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -39,7 +39,6 @@ jobs:
         id: git-diff-action
         with:
           json_diff_file_output: diff.json
-          file_output_only: "true"
       - uses: actions/github-script@v7
         id: check-only-dependency-updates
         with:

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -7,13 +7,33 @@ on:
         required: true
         type: string
 jobs:
-  auto-approve:
+  auto-approve-renovate:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-    if: github.actor == 'renovate[bot]' || github.actor == 'release-please[bot]'
+    if: github.actor == 'renovate[bot]'
     steps:
       - uses: hmarr/auto-approve-action@8f929096a962e83ccdfa8afcf855f39f12d4dac7
+        with:
+          pull-request-number: ${{ inputs.pull-request-number }}
+          review-message: 'Approving auto-generated PR'
+  auto-approve-release-please:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    if: github.actor == 'simpleclub-bot'
+    steps:
+      - name: Get release-please changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v45
+        with:
+          files: |
+            /.github/release-please-manifest.json
+            **/package.json
+            **/CHANGELOG.md
+      - uses: hmarr/auto-approve-action@8f929096a962e83ccdfa8afcf855f39f12d4dac7
+        # Only approve when the modified files have been changed
+        if: steps.changed-files.outputs.only_changed == 'true'
         with:
           pull-request-number: ${{ inputs.pull-request-number }}
           review-message: 'Approving auto-generated PR'

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -43,7 +43,7 @@ jobs:
         id: check-only-dependency-updates
         with:
           script: |
-            const data = JSON.parse('${{steps.git-diff-action.outputs.json-diff}}');
+            const data = ${{steps.git-diff-action.outputs.json-diff}};
             const checkOnlyThreeFilesChange = data.files.length === 3;
             
             const packageJsonFile = data.files.find(file => file.path === 'package.json');

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -22,7 +22,7 @@ jobs:
     permissions:
       pull-requests: write
       contents: read
-    if: github.actor == 'simpleclub-bot' || github.actor == 'IchordeDionysos'
+    if: github.actor == 'simpleclub-bot'
     steps:
       - uses: actions/checkout@v4
         with:
@@ -32,7 +32,6 @@ jobs:
         uses: tj-actions/changed-files@v45
         with:
           files: |
-            .github/workflows/auto-approve.yml
             .github/release-please-manifest.json
             **/package.json
             **/CHANGELOG.md

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -47,7 +47,7 @@ jobs:
             const checkOnlyThreeFilesChange = data.files.length === 3;
             
             const packageJsonFile = data.files.find(file => file.path.endsWith('package.json'));
-            console.log(packageJsonFile);
+            console.log(JSON.stringify(packageJsonFile));
             const packageJsonChunk = packageJsonFile.chunks[0];
             const packageJsonChanges = packageJsonChunk.changes.filter(change => change.type !== 'UnchangedLine');
             const removedVersion = packageJsonChanges.filter(change => change.type === 'RemovedLine')[0]
@@ -62,7 +62,7 @@ jobs:
               didNotUpgradeMajorVersion;
 
             const changelogFile = data.files.find(file => file.path.endsWith('CHANGELOG.md'));
-            console.log(changelogFile);
+            console.log(JSON.stringify(changelogFile));
             const changelogChunk = changelogFile.chunks[0];
             const changelogChanges = packageJsonChunk.changes.filter(change => change.type !== 'UnchangedLine');
             const changelogAllChanges = changelogChanges.filter(change => change.content.match(/^\* /));

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -43,7 +43,7 @@ jobs:
         id: check-only-dependency-updates
         with:
           script: |
-            const data = require('${{steps.git-diff-action.outputs.json-diff-path}}');
+            const data = JSON.parse('${{steps.git-diff-action.outputs.json-diff}}');
             const checkOnlyThreeFilesChange = data.files.length === 3;
             
             const packageJsonFile = data.files.find(file => file.path === 'package.json');

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -32,6 +32,7 @@ jobs:
         uses: tj-actions/changed-files@v45
         with:
           files: |
+            /.github/workflows/auto-approve.yml
             /.github/release-please-manifest.json
             **/package.json
             **/CHANGELOG.md
@@ -44,7 +45,7 @@ jobs:
         with:
           script: |
             const data = ${{steps.git-diff-action.outputs.json-diff}};
-            const checkOnlyThreeFilesChange = data.files.length === 3;
+            const checkOnlyThreeFilesChange = data.files.length === 4;
             
             const packageJsonFile = data.files.find(file => file.path.endsWith('package.json'));
             console.log(JSON.stringify(packageJsonFile));

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -31,7 +31,7 @@ jobs:
             /.github/release-please-manifest.json
             **/package.json
             **/CHANGELOG.md
-      - uses: GrantBirki/git-diff-action@vX.X.X
+      - uses: GrantBirki/git-diff-action@6679c6802dd361f930f603c0a967f0e9f074630b
         id: git-diff-action
         with:
           json_diff_file_output: diff.json


### PR DESCRIPTION
Adds a script that approves release-please PRs when certain conditions are met:
- Only 3 files are changed
- Only a `.github/release-please-manifest.json`, a `package.json`, a `CHANGELOG.md` file are changed
- In the `package.json` only one line has changed
- In the `package.json` only the `"version"` has changed
- In the `package.json` the major version was not changed, but the minor or patch has
- In the `CHANGELOG.md` only one chunk has changed (should always be the case for release-please PRs, as the changes are all done pre-prended at the start)
- In the `CHANGELOG.md` only dependency updates were done
  - This is checked by comparing the number of changes (aka Markdown list items, lines starting with `* `) and the number of dependency related changes (lines starting with `* **deps**: `)
