### PR TITLE
chore: Update CLA link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,5 +43,5 @@ In order for us to review and merge your code, please follow the link and sign t
 [create pr]: https://help.github.com/en/articles/creating-a-pull-request-from-a-fork
 [GitHub hub]: https://hub.github.com
 [ssh key]: https://help.github.com/articles/generating-ssh-keys
-[CLA]: https://bit.ly/simpleclub-cla
+[CLA]: https://cla-assistant.io/simpleclub/
 [versioning]: https://stackoverflow.com/questions/66201337/how-do-dart-package-versions-work-how-should-i-version-my-flutter-plugins/66201338#66201338


### PR DESCRIPTION
## Description

We had to update the link after migrating the CLA tool: https://simpleclub.slack.com/archives/CATPELDMH/p1736153833672199?thread_ts=1733313483.185789&cid=CATPELDMH
Updates https://github.com/simpleclub/.github/pull/3
## Related issues & PRs

[SC-14984]

[SC-14984]: https://simpleclub.atlassian.net/browse/SC-14984?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ